### PR TITLE
feat: add sign_xml/verify_xml, unit tests, CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          pip install -e ".[dev]"
+
+      - name: Run tests
+        run: pytest src/tests/test_adapter.py -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,18 +7,21 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pykalkan"
-version = "1.2.0"
+version = "1.3.0"
 authors = [
     { name = "Shalkarov Temirlan", email = "shalqarov01@gmail.com" },
 ]
 description = "Адаптер(Python) для работы с ЭЦП РК"
 readme = "README.md"
 requires-python = ">=3.7"
+license = "MIT"
 classifiers = [
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: POSIX :: Linux",
 ]
+
+[project.optional-dependencies]
+dev = ["pytest>=7.4.0", "python-dotenv>=1.0.0"]
 
 [project.urls]
 "Homepage" = "https://github.com/shalqarov/pykalkan"

--- a/src/pykalkan/C/lib_handle.py
+++ b/src/pykalkan/C/lib_handle.py
@@ -295,3 +295,70 @@ class LibHandle:
     def set_tsa_url(self, url: bytes):
         kc_url = ct.c_char_p(url)
         self.handle.KC_TSASetUrl(kc_url)
+
+    def sign_xml(self, xml: bytes, flags: t.Iterable[SignatureFlag]) -> bytes:
+        """
+        Подписывает XML-документ (XAdES/XMLDSIG).
+
+        :param xml: входной XML в байтах;
+        :param flags: список флагов подписи;
+        :return: bytes — подписанный XML.
+        """
+        flags = ct.c_int(sum([flag for flag in flags]))
+
+        in_xml = ct.c_char_p(xml)
+        in_xml_len = ct.c_int(len(xml))
+
+        out_len = len(xml) * 2 + 50000
+        out_xml = ct.create_string_buffer(out_len)
+        out_xml_len = ct.pointer(ct.c_int(out_len))
+
+        sign_node_id = ct.c_char_p("".encode())
+        parent_sign_node = ct.c_char_p("".encode())
+        parent_namespace = ct.c_char_p("".encode())
+
+        err_code = self.handle.KC_SignXML(
+            self._alias,
+            flags,
+            in_xml,
+            in_xml_len,
+            out_xml,
+            out_xml_len,
+            sign_node_id,
+            parent_sign_node,
+            parent_namespace,
+        )
+        self.__handle_error(err_code, "KC_SignXML")
+        return out_xml.value
+
+    def verify_xml(self, signed_xml: bytes, flags: t.Iterable[SignatureFlag]) -> dict[str, bytes]:
+        """
+        Верифицирует подписанный XML-документ.
+
+        :param signed_xml: подписанный XML в байтах;
+        :param flags: список флагов;
+        :return: dict с ключами 'Info' и 'Cert'.
+        """
+        flags = ct.c_int(sum([flag for flag in flags]))
+
+        in_xml = ct.c_char_p(signed_xml)
+        in_xml_len = ct.c_int(len(signed_xml))
+
+        out_len = len(signed_xml) * 2 + 50000
+        out_xml = ct.create_string_buffer(out_len)
+        out_xml_len = ct.pointer(ct.c_int(out_len))
+
+        err_code = self.handle.KC_VerifyXML(
+            self._alias,
+            flags,
+            in_xml,
+            in_xml_len,
+            out_xml,
+            out_xml_len,
+        )
+        result = {
+            "Info": out_xml.value,
+            "Cert": b"",
+        }
+        self.__handle_error(err_code, "KC_VerifyXML", result.get("Info"))
+        return result

--- a/src/pykalkan/adapter.py
+++ b/src/pykalkan/adapter.py
@@ -31,7 +31,7 @@ class Adapter(KalkanInterface):
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self._kc.kc_finalize()
-        self._instance = None
+        Adapter._instance = None
 
     def init(self):
         """Инициализация библиотеки.."""
@@ -187,5 +187,46 @@ class Adapter(KalkanInterface):
         """
         with self._lock:
             self._kc.set_tsa_url(url.encode())
+
+    def sign_xml(
+            self,
+            xml: str,
+            flags: t.Iterable[SignatureFlag] = (
+                    SignatureFlag.KC_SIGN_DRAFT,
+                    SignatureFlag.KC_IN_BASE64,
+                    SignatureFlag.KC_OUT_BASE64,
+                    SignatureFlag.KC_WITH_CERT,
+                    SignatureFlag.KC_WITH_TIMESTAMP,
+            ),
+    ) -> bytes:
+        """
+        Подписывает XML-документ (XAdES/XMLDSIG).
+
+        :param xml: str — XML-документ для подписи.
+        :param flags: флаги подписи.
+        :return: bytes — подписанный XML.
+        """
+        with self._lock:
+            return self._kc.sign_xml(xml.encode(), flags)
+
+    def verify_xml(
+            self,
+            signed_xml: str,
+            flags: t.Iterable[SignatureFlag] = (
+                    SignatureFlag.KC_SIGN_DRAFT,
+                    SignatureFlag.KC_IN_BASE64,
+                    SignatureFlag.KC_OUT_BASE64,
+                    SignatureFlag.KC_WITH_CERT,
+            ),
+    ) -> dict[str, bytes]:
+        """
+        Верифицирует подписанный XML-документ.
+
+        :param signed_xml: str — подписанный XML.
+        :param flags: флаги верификации.
+        :return: dict[str, bytes] — результат верификации с ключами 'Info' и 'Cert'.
+        """
+        with self._lock:
+            return self._kc.verify_xml(signed_xml.encode(), flags)
 
 

--- a/src/pykalkan/interface.py
+++ b/src/pykalkan/interface.py
@@ -52,3 +52,11 @@ class KalkanInterface(ABC):
     @abstractmethod
     def set_tsa_url(self, url: str):
         pass
+
+    @abstractmethod
+    def sign_xml(self, xml: str, flags: t.Iterable[SignatureFlag]) -> bytes:
+        pass
+
+    @abstractmethod
+    def verify_xml(self, signed_xml: str, flags: t.Iterable[SignatureFlag]) -> dict[str, bytes]:
+        pass

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -1,0 +1,96 @@
+import ctypes
+from unittest.mock import MagicMock, patch
+import pytest
+
+SIGNED_DATA = b"SIGNED_BASE64_DATA"
+SIGNED_XML = b"<SignedXml><Signature>...</Signature></SignedXml>"
+CERT_BYTES = b"CERT_DATA"
+VERIFY_INFO = b"OK"
+
+
+def make_mock_handle():
+    """Creates a mock ctypes CDLL handle that simulates KalkanCrypt responses."""
+    handle = MagicMock()
+
+    handle.Init.return_value = 0
+    handle.KC_Finalize.return_value = None
+    handle.KC_LoadKeyStore.return_value = 0
+    handle.KC_TSASetUrl.return_value = None
+
+    def mock_sign_data(alias, flags, data, data_len, in_sig, in_sig_len, out, out_len):
+        ctypes.memmove(out, SIGNED_DATA, len(SIGNED_DATA))
+        return 0
+
+    handle.SignData.side_effect = mock_sign_data
+
+    def mock_sign_xml(alias, flags, in_xml, in_xml_len, out, out_len, node_id, parent, ns):
+        ctypes.memmove(out, SIGNED_XML, len(SIGNED_XML))
+        return 0
+
+    handle.KC_SignXML.side_effect = mock_sign_xml
+
+    def mock_verify_data(alias, flags, data, data_len, sign, sign_len,
+                         out_data, out_data_len, out_info, out_info_len,
+                         cert_id, out_cert, out_cert_len):
+        ctypes.memmove(out_info, VERIFY_INFO, len(VERIFY_INFO))
+        ctypes.memmove(out_cert, CERT_BYTES, len(CERT_BYTES))
+        return 0
+
+    handle.VerifyData.side_effect = mock_verify_data
+
+    def mock_verify_xml(alias, flags, in_xml, in_xml_len, out, out_len):
+        ctypes.memmove(out, VERIFY_INFO, len(VERIFY_INFO))
+        return 0
+
+    handle.KC_VerifyXML.side_effect = mock_verify_xml
+
+    def mock_export_cert(alias, flags, out, out_len):
+        ctypes.memmove(out, CERT_BYTES, len(CERT_BYTES))
+        return 0
+
+    handle.X509ExportCertificateFromStore.side_effect = mock_export_cert
+
+    def mock_cert_info(cert, cert_len, prop, out, out_len):
+        value = b"TestValue"
+        ctypes.memmove(out, value, len(value))
+        return 0
+
+    handle.X509CertificateGetInfo.side_effect = mock_cert_info
+
+    handle.X509LoadCertificateFromBuffer.return_value = 0
+
+    def mock_validate(cert, cert_len, valid_type, valid_path, check_time,
+                      out_info, out_info_len, flag, resp, resp_len):
+        ctypes.memmove(out_info, VERIFY_INFO, len(VERIFY_INFO))
+        return 0
+
+    handle.X509ValidateCertificate.side_effect = mock_validate
+
+    def mock_get_time(data, data_len, flags, sig_id, out_time):
+        out_time.contents.value = 1700000000
+        return 0
+
+    handle.KC_GetTimeFromSig.side_effect = mock_get_time
+
+    return handle
+
+
+@pytest.fixture
+def mock_lib(tmp_path):
+    """Patch ctypes.CDLL to return a mock handle. Resets Adapter singleton."""
+    from pykalkan.C.lib_handle import LibHandle
+    from pykalkan.adapter import Adapter
+
+    LibHandle._LibHandle__instance = None
+    Adapter._instance = None
+
+    lib_path = str(tmp_path / "libkalkancryptwr-64.so")
+    open(lib_path, "w").close()
+
+    mock_handle = make_mock_handle()
+
+    with patch("ctypes.CDLL", return_value=mock_handle):
+        yield lib_path
+
+    LibHandle._LibHandle__instance = None
+    Adapter._instance = None

--- a/src/tests/test_adapter.py
+++ b/src/tests/test_adapter.py
@@ -1,0 +1,148 @@
+import pytest
+from pykalkan import Adapter, exceptions
+from pykalkan.enums import SignatureFlag, CertProp, CertCode
+
+DATA_TO_SIGN = "SGVsbG8sIFdvcmxkIQ=="
+XML_TO_SIGN = "<root><data>Hello</data></root>"
+
+
+@pytest.fixture
+def adapter(mock_lib):
+    with Adapter(mock_lib) as kc:
+        kc.load_key_store("/fake/cert.p12", "password")
+        kc.set_tsa_url()
+        yield kc
+
+
+# ── Lifecycle ────────────────────────────────────────────────────────────────
+
+def test_adapter_init(mock_lib):
+    with Adapter(mock_lib) as kc:
+        assert kc is not None
+
+
+def test_adapter_context_manager_cleanup(mock_lib):
+    from pykalkan.adapter import Adapter as A
+    with A(mock_lib) as kc:
+        pass
+    assert A._instance is None
+
+
+# ── sign_data ────────────────────────────────────────────────────────────────
+
+def test_sign_data_returns_bytes(adapter):
+    result = adapter.sign_data(DATA_TO_SIGN)
+    assert isinstance(result, bytes)
+    assert len(result) > 0
+
+
+def test_sign_data_custom_flags(adapter):
+    result = adapter.sign_data(
+        DATA_TO_SIGN,
+        flags=(SignatureFlag.KC_SIGN_CMS, SignatureFlag.KC_IN_BASE64, SignatureFlag.KC_OUT_BASE64),
+    )
+    assert isinstance(result, bytes)
+
+
+# ── verify_data ──────────────────────────────────────────────────────────────
+
+def test_verify_data_returns_dict(adapter):
+    signed = adapter.sign_data(DATA_TO_SIGN)
+    result = adapter.verify_data(signed.decode(), DATA_TO_SIGN)
+    assert isinstance(result, dict)
+    assert "Cert" in result
+    assert "Info" in result
+    assert "Data" in result
+
+
+# ── sign_xml ─────────────────────────────────────────────────────────────────
+
+def test_sign_xml_returns_bytes(adapter):
+    result = adapter.sign_xml(XML_TO_SIGN)
+    assert isinstance(result, bytes)
+    assert len(result) > 0
+
+
+def test_sign_xml_custom_flags(adapter):
+    result = adapter.sign_xml(
+        XML_TO_SIGN,
+        flags=(SignatureFlag.KC_SIGN_DRAFT, SignatureFlag.KC_WITH_CERT),
+    )
+    assert isinstance(result, bytes)
+
+
+# ── verify_xml ───────────────────────────────────────────────────────────────
+
+def test_verify_xml_returns_dict(adapter):
+    signed = adapter.sign_xml(XML_TO_SIGN)
+    result = adapter.verify_xml(signed.decode())
+    assert isinstance(result, dict)
+    assert "Info" in result
+    assert "Cert" in result
+
+
+# ── Certificate operations ───────────────────────────────────────────────────
+
+def test_export_certificate_from_store(adapter):
+    cert = adapter.x509_export_certificate_from_store()
+    assert isinstance(cert, bytes)
+    assert len(cert) > 0
+
+
+def test_certificate_get_info(adapter):
+    cert = adapter.x509_export_certificate_from_store()
+    info = adapter.x509_certificate_get_info(cert.decode(), CertProp.KC_SUBJECT_COMMONNAME)
+    assert isinstance(info, bytes)
+
+
+def test_load_certificate_from_buffer(adapter):
+    cert = adapter.x509_export_certificate_from_store()
+    adapter.x509_load_certificate_from_buffer(cert.decode(), CertCode.KC_CERT_B64)
+
+
+# ── Timestamp ────────────────────────────────────────────────────────────────
+
+def test_get_time_from_sign(adapter):
+    signed = adapter.sign_data(DATA_TO_SIGN)
+    timestamp = adapter.get_time_from_sign(signed.decode())
+    assert isinstance(timestamp, int)
+    assert timestamp > 0
+
+
+# ── Certificate validation ───────────────────────────────────────────────────
+
+def test_validate_certificate_ocsp(adapter):
+    cert = adapter.x509_export_certificate_from_store()
+    result = adapter.x509_validate_certificate_ocsp(cert.decode())
+    assert isinstance(result, dict)
+    assert "info" in result
+
+
+def test_validate_certificate_crl(adapter):
+    cert = adapter.x509_export_certificate_from_store()
+    result = adapter.x509_validate_certificate_crl(cert.decode(), "/fake/crl.crl")
+    assert isinstance(result, dict)
+    assert "info" in result
+
+
+# ── Error handling ───────────────────────────────────────────────────────────
+
+def test_kalkan_exception_on_error(mock_lib):
+    from unittest.mock import patch, MagicMock
+    from pykalkan.C.lib_handle import LibHandle
+    from pykalkan.adapter import Adapter as A
+
+    LibHandle._LibHandle__instance = None
+    A._instance = None
+
+    mock_handle = MagicMock()
+    mock_handle.Init.return_value = 1
+    mock_handle.KC_GetLastErrorString.return_value = b"Test error"
+
+    with patch("ctypes.CDLL", return_value=mock_handle):
+        with pytest.raises(exceptions.KalkanException):
+            with A(mock_lib) as kc:
+                pass
+
+    LibHandle._LibHandle__instance = None
+    A._instance = None


### PR DESCRIPTION
This pull request introduces major improvements to the `pykalkan` library, including the addition of XML signature and verification support, enhanced test coverage with new tests and fixtures, and improvements to the development workflow. The changes also include dependency updates and minor bug fixes.

**New features: XML signing and verification**

* Added `sign_xml` and `verify_xml` methods to the `LibHandle` class (`src/pykalkan/C/lib_handle.py`), `Adapter` class (`src/pykalkan/adapter.py`), and the `Interface` (`src/pykalkan/interface.py`), enabling signing and verification of XML documents using XAdES/XMLDSIG. [[1]](diffhunk://#diff-edfb29e5a1b425929fc0e9cca98c693e48cab9eb8dd427bfae09ee894329c527R298-R364) [[2]](diffhunk://#diff-d5e75086b7835bc72b3bf89c48dbe22d6f486d13b7bc344b99da10a778f79ee7R191-R231) [[3]](diffhunk://#diff-dc2045bf0a51d22d73e831ebdbebe38ae8c636a9243f1e8e7983b3bf4dd39d25R55-R62)

**Testing improvements**

* Introduced comprehensive tests for the adapter, including XML signing/verification, certificate operations, timestamp retrieval, and error handling (`src/tests/test_adapter.py`).
* Added a `pytest` fixture and mock for the KalkanCrypt library to enable isolated and reliable unit testing (`src/tests/conftest.py`).

**Development workflow and dependencies**

* Added a GitHub Actions CI workflow to automatically test the library on multiple Python versions (`.github/workflows/ci.yml`).
* Added a `[project.optional-dependencies]` section in `pyproject.toml` for development dependencies (`pytest`, `python-dotenv`), and updated the version to `1.3.0`. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R23-R25) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L10-R10)

**Bug fixes**

* Fixed singleton cleanup in the `Adapter` context manager to properly reset the `_instance` attribute (`src/pykalkan/adapter.py`).